### PR TITLE
Update from node-template and study-template

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,15 @@
+{
+  "preset": "airbnb",
+  "disallowMultipleVarDecl": "exceptUndefined",
+  "disallowSpaceAfterObjectKeys": {
+    "allExcept": ["method"]
+  },
+  "requirePaddingNewLinesAfterBlocks": {
+    "allExcept": ["inCallExpressions", "inArrayExpressions", "inProperties"]
+  },
+  "requireSpacesInAnonymousFunctionExpression": {
+    "beforeOpeningRoundBrace": true,
+    "beforeOpeningCurlyBrace": true
+  },
+  "validateIndentation": 2
+}

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,15 @@
+{
+  "curly": true,
+  "devel": true,
+  "eqeqeq": true,
+  "esversion": 6,
+  "latedef": true,
+  "mocha": true,
+  "noarg": true,
+  "node": true,
+  "nonew": true,
+  "strict": "global",
+  "undef": true,
+  "unused": true,
+  "varstmt": true
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,12 @@
+'use strict';
+
+// http://ericnish.io/blog/how-to-neatly-separate-grunt-files
+// http://www.html5rocks.com/en/tutorials/tooling/supercharging-your-gruntfile/
+// discuss how to break up gruntfiles
+
+module.exports = function(grunt) {
+
+  require('time-grunt')(grunt);
+  require('load-grunt-config')(grunt);
+
+};

--- a/bin/example.js
+++ b/bin/example.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+'use strict';
+
+console.log('Hello, world!');

--- a/grunt/aliases.json
+++ b/grunt/aliases.json
@@ -1,0 +1,6 @@
+{
+  "default": ["nag"],
+  "nag": ["jshint", "jsonlint:all", "jscs:status"],
+  "reformat": ["jscs:write"],
+  "test": ["mochaTest:test"]
+}

--- a/grunt/jscs.json
+++ b/grunt/jscs.json
@@ -1,0 +1,19 @@
+{
+  "options": {
+    "config": ".jscsrc"
+  },
+
+  "status": {
+    "src": ["<%= paths.src.all %>"],
+    "options": {
+      "force": true
+    }
+  },
+
+  "write": {
+    "src": ["<%= paths.src.all %>"],
+    "options": {
+      "fix": true
+    }
+  }
+}

--- a/grunt/jshint.json
+++ b/grunt/jshint.json
@@ -1,0 +1,8 @@
+{
+  "all": {
+    "src": ["<%= paths.src.all %>"]
+  },
+  "options": {
+    "jshintrc": true
+  }
+}

--- a/grunt/jsonlint.json
+++ b/grunt/jsonlint.json
@@ -1,0 +1,5 @@
+{
+  "all": {
+    "src": ["<%= paths.json.all %>"]
+  }
+}

--- a/grunt/mochaTest.json
+++ b/grunt/mochaTest.json
@@ -1,0 +1,8 @@
+{
+  "test": {
+    "options": {
+      "quiet": false
+    },
+    "src": ["<%=  paths.src.spec %> "]
+  }
+}

--- a/grunt/paths.json
+++ b/grunt/paths.json
@@ -1,0 +1,29 @@
+{
+  "src": {
+    "all": [
+      "lib/**/*.js",
+      "spec/**/*.spec.js"
+    ],
+    "spec": [
+      "spec/**/*.spec.js"
+    ],
+    "lib": [
+      "lib/**/*.js"
+    ]
+  },
+
+  "grunt": {
+    "all": [
+      "Gruntfile.js",
+      "grunt/*.js"
+    ]
+  },
+
+  "json": {
+    "all": [
+      "lib/**/*.json",
+      "spec/**/*.json",
+      "grunt/*.json"
+    ]
+  }
+}

--- a/lib/example.js
+++ b/lib/example.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  sync: (value) => value,
+  async: (value, cb) => setTimeout(() => cb(null, value), 0),
+  promise: (value) => Promise.resolve(value),
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "ga-wdi-boston.node-template",
+  "version": "0.0.1",
+  "private": true,
+  "scripts":{
+    "start": "node bin/example.js"
+  },
+  "license": {
+    "software": "GNU GPLv3",
+    "content": "CC­BY­NC­SA 4.0"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "chai-as-promised": "^6.0.0",
+    "grunt": "^1.0.1",
+    "grunt-concurrent": "^2.3.1",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-jscs": "^3.0.1",
+    "grunt-jsonlint": "^1.1.0",
+    "grunt-mocha-test": "^0.13.2",
+    "grunt-nodemon": "^0.4.2",
+    "load-grunt-config": "^0.19.2",
+    "mocha": "^3.1.2",
+    "time-grunt": "^1.4.0"
+  }
+}

--- a/spec/example.spec.js
+++ b/spec/example.spec.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// Allow chai syntax like `expect(foo).to.be.ok;`
+// jshint -W030
+
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+
+chai.use(chaiAsPromised);
+
+const expect = chai.expect;
+
+const example = require('../lib/example');
+
+describe('Sync', function () {
+  it('is true', function () {
+    expect(example.sync(true)).to.be.true;
+  });
+});
+
+describe('Async', function () {
+  it('is true', function (done) {
+    example.async(true, function (error, value) {
+      if (error || value !== true) {
+        error = error || new Error(`value is ${value}`);
+      }
+
+      done(error);
+    });
+  });
+});
+
+describe('Promise', function () {
+  it('is true', function () {
+    return expect(example.promise(true)).to.eventually.be.true;
+  });
+});


### PR DESCRIPTION
Refresh for cohort 016.  The `study-template` did not require any changes to be made (the logo and license appear correct).  I did not see a use case for the `node-template` in the actual exercise but since the repo name began with `js-` I added the `node-template`.  